### PR TITLE
Don't show sticker picker when replying to a message

### DIFF
--- a/ts/components/CompositionArea.tsx
+++ b/ts/components/CompositionArea.tsx
@@ -655,35 +655,36 @@ export const CompositionArea = memo(function CompositionArea({
     </>
   ) : null;
 
+  const shouldShowStickers =
+    !quotedMessageProps && !draftEditMessage && withStickers;
   const stickerButtonPlacement = large ? 'top-start' : 'top-end';
-  const stickerButtonFragment =
-    !draftEditMessage && withStickers ? (
-      <div className="CompositionArea__button-cell">
-        <StickerButton
-          i18n={i18n}
-          knownPacks={knownPacks}
-          receivedPacks={receivedPacks}
-          installedPack={installedPack}
-          installedPacks={installedPacks}
-          blessedPacks={blessedPacks}
-          recentStickers={recentStickers}
-          clearInstalledStickerPack={clearInstalledStickerPack}
-          onClickAddPack={() =>
-            pushPanelForConversation({
-              type: PanelType.StickerManager,
-            })
-          }
-          onPickSticker={(packId, stickerId) =>
-            sendStickerMessage(conversationId, { packId, stickerId })
-          }
-          showIntroduction={showIntroduction}
-          clearShowIntroduction={clearShowIntroduction}
-          showPickerHint={showPickerHint}
-          clearShowPickerHint={clearShowPickerHint}
-          position={stickerButtonPlacement}
-        />
-      </div>
-    ) : null;
+  const stickerButtonFragment = shouldShowStickers ? (
+    <div className="CompositionArea__button-cell">
+      <StickerButton
+        i18n={i18n}
+        knownPacks={knownPacks}
+        receivedPacks={receivedPacks}
+        installedPack={installedPack}
+        installedPacks={installedPacks}
+        blessedPacks={blessedPacks}
+        recentStickers={recentStickers}
+        clearInstalledStickerPack={clearInstalledStickerPack}
+        onClickAddPack={() =>
+          pushPanelForConversation({
+            type: PanelType.StickerManager,
+          })
+        }
+        onPickSticker={(packId, stickerId) =>
+          sendStickerMessage(conversationId, { packId, stickerId })
+        }
+        showIntroduction={showIntroduction}
+        clearShowIntroduction={clearShowIntroduction}
+        showPickerHint={showPickerHint}
+        clearShowPickerHint={clearShowPickerHint}
+        position={stickerButtonPlacement}
+      />
+    </div>
+  ) : null;
 
   // Listen for cmd/ctrl-shift-x to toggle large composition mode
   useEffect(() => {


### PR DESCRIPTION
<div>
        <div class="edit-comment-hide">
  
  <task-lists disabled="" sortable="">
    <div class="comment-body markdown-body js-comment-body soft-wrap css-overflow-wrap-anywhere user-select-contain d-block">
      <p dir="auto">The sticker picker could be opened when the user is about to send an attachment, or a reply, or text, neither of which can be combined with stickers.</p>
<p dir="auto">I have personally witnessed many users thinking they could reply to a message with a sticker, then be surprised when the sticker they sent does not include the reply. This change makes it clear that you cannot send stickers as a reply to a message, or with text/attachments. Note that this behavior follows what iOS is doing, and I think Android should do the same.</p>


<h3 dir="auto">First time contributor checklist:</h3>
<ul class="contains-task-list">
<li class="task-list-item"><span class="handle"><svg class="drag-handle" aria-hidden="true" width="16" height="16"><path d="M10 13a1 1 0 100-2 1 1 0 000 2zm-4 0a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zm3 1a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zM6 5a1 1 0 100-2 1 1 0 000 2z"></path></svg></span><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" checked=""> I have read the <a href="https://github.com/signalapp/Signal-Desktop/blob/main/README.md">README</a> and <a href="https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md">Contributor Guidelines</a></li>
<li class="task-list-item"><span class="handle"><svg class="drag-handle" aria-hidden="true" width="16" height="16"><path d="M10 13a1 1 0 100-2 1 1 0 000 2zm-4 0a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zm3 1a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zM6 5a1 1 0 100-2 1 1 0 000 2z"></path></svg></span><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" checked=""> I have signed the <a href="https://signal.org/cla/" rel="nofollow">Contributor Licence Agreement</a></li>
</ul>
<h3 dir="auto">Contributor checklist:</h3>
<ul class="contains-task-list">
<li class="task-list-item"><span class="handle"><svg class="drag-handle" aria-hidden="true" width="16" height="16"><path d="M10 13a1 1 0 100-2 1 1 0 000 2zm-4 0a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zm3 1a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zM6 5a1 1 0 100-2 1 1 0 000 2z"></path></svg></span><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" checked=""> My contribution is <strong>not</strong> related to translations.</li>
<li class="task-list-item"><span class="handle"><svg class="drag-handle" aria-hidden="true" width="16" height="16"><path d="M10 13a1 1 0 100-2 1 1 0 000 2zm-4 0a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zm3 1a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zM6 5a1 1 0 100-2 1 1 0 000 2z"></path></svg></span><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" checked=""> My commits are in nice logical chunks with <a href="http://chris.beams.io/posts/git-commit/" rel="nofollow">good commit messages</a></li>
<li class="task-list-item"><span class="handle"><svg class="drag-handle" aria-hidden="true" width="16" height="16"><path d="M10 13a1 1 0 100-2 1 1 0 000 2zm-4 0a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zm3 1a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zM6 5a1 1 0 100-2 1 1 0 000 2z"></path></svg></span><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" checked=""> My changes are <a href="https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372" rel="nofollow">rebased</a> on the latest <a href="https://github.com/signalapp/Signal-Desktop/tree/main"><code class="notranslate">main</code></a> branch</li>
<li class="task-list-item"><span class="handle"><svg class="drag-handle" aria-hidden="true" width="16" height="16"><path d="M10 13a1 1 0 100-2 1 1 0 000 2zm-4 0a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zm3 1a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zM6 5a1 1 0 100-2 1 1 0 000 2z"></path></svg></span><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" checked=""> A <code class="notranslate">npm run ready</code> run passes successfully (<a href="https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests">more about tests here</a>)</li>
<li class="task-list-item"><span class="handle"><svg class="drag-handle" aria-hidden="true" width="16" height="16"><path d="M10 13a1 1 0 100-2 1 1 0 000 2zm-4 0a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zm3 1a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zM6 5a1 1 0 100-2 1 1 0 000 2z"></path></svg></span><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" checked=""> My changes are ready to be shipped to users</li>
</ul>
<h3 dir="auto">Description</h3>


  </task-lists>
  </div>