### PR TITLE
fix for window not being shown with wayland in same cases by switching to the 'did-finish-load' event instead of 'ready-to-show'

### DIFF
--- a/app/main.ts
+++ b/app/main.ts
@@ -992,7 +992,7 @@ async function createWindow() {
     }
   });
 
-  mainWindow.once('ready-to-show', async () => {
+  mainWindow.webContents.once('did-finish-load', async () => {
     getLogger().info('main window is ready-to-show');
 
     // Ignore sql errors and show the window anyway


### PR DESCRIPTION
<div>
        <div class="edit-comment-hide">
  
  <task-lists disabled="" sortable="">
    <div class="comment-body markdown-body js-comment-body soft-wrap css-overflow-wrap-anywhere user-select-contain d-block">
      <h3 dir="auto">First time contributor checklist:</h3>
<ul class="contains-task-list">
<li class="task-list-item" draggable="false"><span class="handle"><svg class="drag-handle" aria-hidden="true" width="16" height="16"><path d="M10 13a1 1 0 100-2 1 1 0 000 2zm-4 0a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zm3 1a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zM6 5a1 1 0 100-2 1 1 0 000 2z"></path></svg></span><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" checked=""> I have read the <a href="https://github.com/signalapp/Signal-Desktop/blob/main/README.md">README</a> and <a href="https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md">Contributor Guidelines</a></li>
<li class="task-list-item" draggable="false"><span class="handle"><svg class="drag-handle" aria-hidden="true" width="16" height="16"><path d="M10 13a1 1 0 100-2 1 1 0 000 2zm-4 0a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zm3 1a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zM6 5a1 1 0 100-2 1 1 0 000 2z"></path></svg></span><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" checked=""> I have signed the <a href="https://signal.org/cla/" rel="nofollow">Contributor Licence Agreement</a></li>
</ul>
<h3 dir="auto">Contributor checklist:</h3>
<ul class="contains-task-list">
<li class="task-list-item"><span class="handle"><svg class="drag-handle" aria-hidden="true" width="16" height="16"><path d="M10 13a1 1 0 100-2 1 1 0 000 2zm-4 0a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zm3 1a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zM6 5a1 1 0 100-2 1 1 0 000 2z"></path></svg></span><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" checked=""> My contribution is <strong>not</strong> related to translations.</li>
<li class="task-list-item"><span class="handle"><svg class="drag-handle" aria-hidden="true" width="16" height="16"><path d="M10 13a1 1 0 100-2 1 1 0 000 2zm-4 0a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zm3 1a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zM6 5a1 1 0 100-2 1 1 0 000 2z"></path></svg></span><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" checked=""> My commits are in nice logical chunks with <a href="http://chris.beams.io/posts/git-commit/" rel="nofollow">good commit messages</a></li>
<li class="task-list-item"><span class="handle"><svg class="drag-handle" aria-hidden="true" width="16" height="16"><path d="M10 13a1 1 0 100-2 1 1 0 000 2zm-4 0a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zm3 1a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zM6 5a1 1 0 100-2 1 1 0 000 2z"></path></svg></span><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" checked=""> My changes are <a href="https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372" rel="nofollow">rebased</a> on the latest <a href="https://github.com/signalapp/Signal-Desktop/tree/main"><code class="notranslate">main</code></a> branch</li>
<li class="task-list-item"><span class="handle"><svg class="drag-handle" aria-hidden="true" width="16" height="16"><path d="M10 13a1 1 0 100-2 1 1 0 000 2zm-4 0a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zm3 1a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zM6 5a1 1 0 100-2 1 1 0 000 2z"></path></svg></span><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" checked=""> A <code class="notranslate">npm run ready</code> run passes successfully (<a href="https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests">more about tests here</a>)</li>
<li class="task-list-item"><span class="handle"><svg class="drag-handle" aria-hidden="true" width="16" height="16"><path d="M10 13a1 1 0 100-2 1 1 0 000 2zm-4 0a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zm3 1a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zM6 5a1 1 0 100-2 1 1 0 000 2z"></path></svg></span><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" checked=""> My changes are ready to be shipped to users</li>
</ul>
<h3 dir="auto">related issues:</h3>
<ul dir="auto">
<li><span class="issue-keyword tooltipped tooltipped-se" aria-label="This pull request closes issue #6368.">fixes</span> <span class="reference"><svg class="octicon octicon-issue-opened open mr-1" title="Open" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z"></path><path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Z"></path></svg><a class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="1665414436" data-permission-text="Title is private" data-url="https://github.com/signalapp/Signal-Desktop/issues/6368" data-hovercard-type="issue" data-hovercard-url="/signalapp/Signal-Desktop/issues/6368/hovercard" href="https://github.com/signalapp/Signal-Desktop/issues/6368">Wayland: does not show window without a patch on newer electron versions<span class="issue-shorthand">&nbsp;#6368</span></a></span></li>
<li><span class="issue-keyword tooltipped tooltipped-se" aria-label="This pull request closes issue #6740.">fixes</span> <span class="reference"><svg class="octicon octicon-issue-opened open mr-1" title="Open" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z"></path><path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Z"></path></svg><a class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="2067349261" data-permission-text="Title is private" data-url="https://github.com/signalapp/Signal-Desktop/issues/6740" data-hovercard-type="issue" data-hovercard-url="/signalapp/Signal-Desktop/issues/6740/hovercard" href="https://github.com/signalapp/Signal-Desktop/issues/6740">Main window does only conditionally open up when using wayland (signal-desktop 6.43.1)<span class="issue-shorthand">&nbsp;#6740</span></a></span></li>
<li><span class="reference"><svg class="octicon octicon-issue-closed closed mr-1" title="Closed" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path d="M11.28 6.78a.75.75 0 0 0-1.06-1.06L7.25 8.69 5.78 7.22a.75.75 0 0 0-1.06 1.06l2 2a.75.75 0 0 0 1.06 0l3.5-3.5Z"></path><path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0Zm-1.5 0a6.5 6.5 0 1 0-13 0 6.5 6.5 0 0 0 13 0Z"></path></svg><a class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="2448568627" data-permission-text="Title is private" data-url="https://github.com/signalapp/Signal-Desktop/issues/6966" data-hovercard-type="issue" data-hovercard-url="/signalapp/Signal-Desktop/issues/6966/hovercard" href="https://github.com/signalapp/Signal-Desktop/issues/6966">signal-desktop hangs on startup, appearing to start minimised<span class="issue-shorthand">&nbsp;#6966</span></a></span></li>
</ul>
<h3 dir="auto">Description</h3>
<p dir="auto">on some setups signal is never shown due to electrons <code class="notranslate">ready-to-show</code> event is not firing.</p>
<p dir="auto">I've found that people use <code class="notranslate">did-finish-load</code> instead due to (probably) this bug (<a class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="689967764" data-permission-text="Title is private" data-url="https://github.com/electron/electron/issues/25253" data-hovercard-type="issue" data-hovercard-url="/electron/electron/issues/25253/hovercard?comment_id=691624779&amp;comment_type=issue_comment" href="https://github.com/electron/electron/issues/25253#issuecomment-691624779">electron/electron#25253 (comment)</a>).</p>
<p dir="auto">After a deep rabbit hole into electron and the chromium source code I could not determine why this event is not fired, but both events should be more or less equal from their timing in our case, so it is a workaround, but can be used permanently.</p>
<p dir="auto"><a href="https://www.electronjs.org/docs/latest/api/browser-window" rel="nofollow">https://www.electronjs.org/docs/latest/api/browser-window</a></p>
<blockquote>
<h3 dir="auto">Using the <code class="notranslate">ready-to-show</code> event</h3>
<p dir="auto">This event is usually emitted after the did-finish-load event, but for pages with many remote resources, it may be emitted before the did-finish-load event.</p>
</blockquote>
<h3 dir="auto">setup with which I could reproduce the issue and verify the fix</h3>
<ul dir="auto">
<li>latest <code class="notranslate">main</code> (<code class="notranslate">git checkout v7.35.0-alpha.1</code>)</li>
<li>electron v33.1.0</li>
<li>node v20.18.0</li>
<li>Sway Desktop (wayland/wlroots-based)</li>
<li><code class="notranslate">ELECTRON_OZONE_PLATFORM_HINT=auto</code> environment variable</li>
</ul>
    </div>
  </task-lists>
  
</div>

